### PR TITLE
ToolTip_XPBar 위젯의 Text를 설정할 때 LogTextFormatter: Warning: Failed to parse argument 오류가 발생하는 현상 수정

### DIFF
--- a/Source/Aura/Private/UI/Widget/ToolTip_XPBar.cpp
+++ b/Source/Aura/Private/UI/Widget/ToolTip_XPBar.cpp
@@ -10,15 +10,10 @@ void UToolTip_XPBar::NativeConstruct()
 {
 	Super::NativeConstruct();
 
-	{
-		const FString Format = TEXT("<Tan>Level {Level} </><Normal>({Percent}%)</>");
-		const int32 Percent = FMath::TruncToInt32(UKismetMathLibrary::SafeDivide(XP, XPRequirement) * 100.f);
-		const FText Text = FText::Format(FTextFormat::FromString(Format), Level, Percent);
-		Text_Level->SetText(Text);
-	}
-	{
-		const FString Format = TEXT("<Tan>XP: </><Normal>{XP} </><Tan>/ Next Level: </><Normal>{XPRequirement}</>");
-		const FText Text = FText::Format(FTextFormat::FromString(Format), FMath::TruncToInt32(XP), FMath::TruncToInt32(XPRequirement));
-		Text_XP->SetText(Text);
-	}
+	const int32 Percent = FMath::TruncToInt32(UKismetMathLibrary::SafeDivide(XP, XPRequirement) * 100.f);
+	const FString LevelString = FString::Printf(TEXT("<Tan>Level %d </><Normal>(%d%%)</>"), Level, Percent);
+	Text_Level->SetText(FText::FromString(LevelString));
+
+	const FString XPString = FString::Printf(TEXT("<Tan>XP: </><Normal>%d </><Tan>/ Next Level: </><Normal>%d</>"), FMath::TruncToInt32(XP), FMath::TruncToInt32(XPRequirement));
+	Text_XP->SetText(FText::FromString(XPString));
 }


### PR DESCRIPTION
## 연관된 이슈

#210 

## 작업 내용

ToolTip_XPBar 위젯의 Text를 설정할 때 FText::Format()에서 아래의 오류가 발생한다.
FText의 기능을 사용하지 않으므로 FText::Format 대신 FString을 변환하는 방법으로 변경한다.
```
LogTextFormatter: Warning: Failed to parse argument "Level" as a number (using "0" as a fallback). Please check your format string for errors: "<Tan>Level {Level} </><Normal>({Percent}%)</>".
LogTextFormatter: Warning: Failed to parse argument "Percent" as a number (using "1" as a fallback). Please check your format string for errors: "<Tan>Level {Level} </><Normal>({Percent}%)</>".
LogTextFormatter: Warning: Failed to parse argument "XP" as a number (using "0" as a fallback). Please check your format string for errors: "<Tan>XP: </><Normal>{XP} </><Tan>/ Next Level: </><Normal>{XPRequirement}</>".
LogTextFormatter: Warning: Failed to parse argument "XPRequirement" as a number (using "1" as a fallback). Please check your format string for errors: "<Tan>XP: </><Normal>{XP} </><Tan>/ Next Level: </><Normal>{XPRequirement}</>".
```

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요