### PR TITLE
서버에서만 CommitAbility를 수행하도록 변경

### DIFF
--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraDamageAbility.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraDamageAbility.cpp
@@ -81,7 +81,10 @@ void UAuraDamageAbility::FinishMontage()
 
 void UAuraDamageAbility::OnEventReceived(FGameplayEventData Payload)
 {
-	K2_CommitAbility();
+	if (HasAuthority(&CurrentActivationInfo))
+	{
+		K2_CommitAbility();
+	}
 }
 
 void UAuraDamageAbility::FinishAttack()


### PR DESCRIPTION
## 연관된 이슈

#197 

## 작업 내용

클라이언트에서 CommitAbility를 수행하면, Mana Cost Instant GameplayEffect에 의해 Mana Attribute가 변경될 때 Base Value가 아닌 Current Value가 변경되는 현상이 발생한다.
이 현상으로 인해 Mana가 제대로 회복되지 않는 문제가 발생한다.
이를 해결하기 위해 서버에서만 CommitAbility를 수행하도록 변경한다.

참고로 ActivateAbility에서 바로 CommitAbility를 수행하면 문제가 없는데, 이번 경우처럼 어빌리티 실행 후 나중에 CommitAbility를 수행하면 문제가 발생한다. (LocalPredicted, InstancedPerActor)


## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요