### PR TITLE
Enemy에 귀속되는 Ability가 Enemy Spawn Level을 따르도록 변경

### DIFF
--- a/Source/Aura/Private/AbilitySystem/AuraAbilitySystemComponent.cpp
+++ b/Source/Aura/Private/AbilitySystem/AuraAbilitySystemComponent.cpp
@@ -54,14 +54,14 @@ void UAuraAbilitySystemComponent::OnAbilityFailed(const UGameplayAbility* Abilit
 	}
 }
 
-void UAuraAbilitySystemComponent::AddAbilities(const TArray<TSubclassOf<UGameplayAbility>>& Abilities)
+void UAuraAbilitySystemComponent::AddAbilities(const TArray<TSubclassOf<UGameplayAbility>>& Abilities, int32 InLevel)
 {
 	const AAuraGameStateBase* AuraGameStateBase = GetWorld() ? GetWorld()->GetGameState<AAuraGameStateBase>() : nullptr;
 	check(AuraGameStateBase && AuraGameStateBase->AuraInputConfig);
 	
 	for (const TSubclassOf<UGameplayAbility>& AbilityClass : Abilities)
 	{
-		FGameplayAbilitySpec AbilitySpec(AbilityClass, 1);
+		FGameplayAbilitySpec AbilitySpec(AbilityClass, InLevel);
 		if (const UAuraGameplayAbility* AuraGameplayAbility = Cast<UAuraGameplayAbility>(AbilitySpec.Ability))
 		{
 			if (AuraGameplayAbility->StartupInputTag.IsValid())

--- a/Source/Aura/Private/Character/AuraEnemy.cpp
+++ b/Source/Aura/Private/Character/AuraEnemy.cpp
@@ -124,7 +124,8 @@ void AAuraEnemy::InitAbilityActorInfo()
 			AddStartupAbilities(EnemyClassConfig->SharedAbilities);
 		}
 		// 특정 Enemy에 귀속되는 GameplayAbility 추가
-		AddStartupAbilities(StartupAbilities);
+		// - Enemy Spawn Level을 따름
+		AddStartupAbilities(StartupAbilities, SpawnLevel);
 	}
 
 	// Abilities.HitReact Tag의 Added, Removed Event에 Binding

--- a/Source/Aura/Private/Character/BaseCharacter.cpp
+++ b/Source/Aura/Private/Character/BaseCharacter.cpp
@@ -96,12 +96,12 @@ void ABaseCharacter::BeginPlay()
 	
 }
 
-void ABaseCharacter::AddStartupAbilities(const TArray<TSubclassOf<UGameplayAbility>>& AbilityClasses) const
+void ABaseCharacter::AddStartupAbilities(const TArray<TSubclassOf<UGameplayAbility>>& AbilityClasses, int32 InLevel) const
 {
 	if (HasAuthority())
 	{
 		UAuraAbilitySystemComponent* AuraASC = CastChecked<UAuraAbilitySystemComponent>(AbilitySystemComponent);
-		AuraASC->AddAbilities(AbilityClasses);
+		AuraASC->AddAbilities(AbilityClasses, InLevel);
 	}
 }
 

--- a/Source/Aura/Private/Game/StageGameMode.cpp
+++ b/Source/Aura/Private/Game/StageGameMode.cpp
@@ -332,7 +332,12 @@ void AStageGameMode::AsyncSpawnEnemies()
 
 void AStageGameMode::OnPlayerLevelAttributeChanged(const FOnAttributeChangeData& Data)
 {
-	EnemySpawnLevel += 0.5f;
+	if (GetWorld())
+	{
+		// 모든 플레이어의 평균 레벨 증가량을 반영하여 EnemySpawnLevel 업데이트
+		const float AddAmount = 1.f / GetWorld()->GetNumPlayerControllers();
+		EnemySpawnLevel += AddAmount;
+	}
 }
 
 void AStageGameMode::SpawnEnemy(TSubclassOf<AAuraEnemy> Class)

--- a/Source/Aura/Public/AbilitySystem/AuraAbilitySystemComponent.h
+++ b/Source/Aura/Public/AbilitySystem/AuraAbilitySystemComponent.h
@@ -38,7 +38,7 @@ public:
 	void OnAbilityFailed(const UGameplayAbility* Ability, const FGameplayTagContainer& FailureTags);
 	
 	// Abilities의 Ability Class의 AbilitySpec을 생성해 GiveAbility를 수행하는 함수 
-	void AddAbilities(const TArray<TSubclassOf<UGameplayAbility>>& Abilities);
+	void AddAbilities(const TArray<TSubclassOf<UGameplayAbility>>& Abilities, int32 InLevel);
 
 	// InputID에 해당하는 Ability의 Press Event를 발생시키는 함수
 	void AbilityInputPressed(int32 InputID);

--- a/Source/Aura/Public/Character/BaseCharacter.h
+++ b/Source/Aura/Public/Character/BaseCharacter.h
@@ -77,7 +77,7 @@ protected:
 	virtual void InitializeAttributes() {}
 
 
-	void AddStartupAbilities(const TArray<TSubclassOf<UGameplayAbility>>& AbilityClasses) const;
+	void AddStartupAbilities(const TArray<TSubclassOf<UGameplayAbility>>& AbilityClasses, int32 InLevel = 1) const;
 
 	// ============================================================================
 	// Role


### PR DESCRIPTION
## 연관된 이슈

#199 

## 작업 내용

Enemy Attack Ability와 같이 특정 Enemy에 귀속되는 Ability를 추가할 때, Enemy Spawn Level을 따르도록 변경한다.
또한 GameMode에서 EnemySpawnLevel을 계산할 때 로직 오류를 수정한다.

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요