### PR TITLE
OnlyWall Channel을 다시 Trace Channel로 변경

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -134,7 +134,7 @@ bAllowClientSideNavigation=True
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel2,DefaultResponse=ECR_Ignore,bTraceType=True,bStaticObject=False,Name="EQS_Overlap")
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel3,DefaultResponse=ECR_Block,bTraceType=True,bStaticObject=False,Name="ClickToMove")
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel4,DefaultResponse=ECR_Block,bTraceType=True,bStaticObject=False,Name="Target")
-+DefaultChannelResponses=(Channel=ECC_GameTraceChannel5,DefaultResponse=ECR_Ignore,bTraceType=false,bStaticObject=False,Name="OnlyWall")
++DefaultChannelResponses=(Channel=ECC_GameTraceChannel5,DefaultResponse=ECR_Ignore,bTraceType=True,bStaticObject=False,Name="OnlyWall")
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel6,DefaultResponse=ECR_Block,bTraceType=False,bStaticObject=False,Name="Enemy")
 -ProfileRedirects=(OldName="BlockingVolume",NewName="InvisibleWall")
 -ProfileRedirects=(OldName="InterpActor",NewName="IgnoreOnlyPawn")

--- a/Source/Aura/Aura.h
+++ b/Source/Aura/Aura.h
@@ -33,8 +33,8 @@
 // Default Response Block, Ignore BaseCharacter's Mesh and Capsule, Block Enemy's Mesh
 #define ECC_Target ECollisionChannel::ECC_GameTraceChannel4
 
-// 레벨의 벽 메시만 Block하는 Object Channel
-// Default Response Ignore, Block Wall Mesh in Level, Overlap Wall FadeActor
+// 레벨의 벽 메시만 Block하는 Trace Channel
+// Default Response Ignore, Block Wall Mesh and FadeActor in Level
 #define ECC_OnlyWall ECollisionChannel::ECC_GameTraceChannel5
 
 // Enemy를 나타내는 Object Channel


### PR DESCRIPTION

## 연관된 이슈

#226 

## 작업 내용

- EQ_FindMeleeAttackPosition의 Trace Test에서 OnlyWall Trace Channel을 사용하기 때문에 Object Channel을 사용할 수 없음
- 굳이 필요하지 않음

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요