### PR TITLE
Health, Mana Globe의 ToolTip Widget이 값을 표시할 때 소수점 한자리까지만 표시하도록 변경

### DIFF
--- a/Source/Aura/Private/UI/Widget/EquippedSpellGlobe.cpp
+++ b/Source/Aura/Private/UI/Widget/EquippedSpellGlobe.cpp
@@ -13,6 +13,9 @@ UEquippedSpellGlobe::UEquippedSpellGlobe(const FObjectInitializer& ObjectInitial
 	NormalColor = FLinearColor::White;
 	CooldownColor = FLinearColor(0.25f, 0.25f, 0.25f);
 	CooldownUpdateInterval = 0.05f;
+
+	NumberFormattingOptions.MinimumFractionalDigits = 1;
+	NumberFormattingOptions.MaximumFractionalDigits = 1;
 }
 
 void UEquippedSpellGlobe::UpdateEquippedSpellChange(bool bEquipped, const FSpellInfo& SpellInfo) const
@@ -60,8 +63,5 @@ void UEquippedSpellGlobe::UpdateTextCooldown()
 {
 	RemainingTime = FMath::Max(0.f, RemainingTime - CooldownUpdateInterval);
 	
-	FNumberFormattingOptions Options;
-	Options.MinimumFractionalDigits = 1;
-	Options.MaximumFractionalDigits = 1;
-	Text_Cooldown->SetText(FText::AsNumber(RemainingTime, &Options));
+	Text_Cooldown->SetText(FText::AsNumber(RemainingTime, &NumberFormattingOptions));
 }

--- a/Source/Aura/Private/UI/Widget/StageWaitingTimer.cpp
+++ b/Source/Aura/Private/UI/Widget/StageWaitingTimer.cpp
@@ -10,6 +10,8 @@ UStageWaitingTimer::UStageWaitingTimer(const FObjectInitializer& ObjectInitializ
 	: Super(ObjectInitializer)
 {
 	TranslationTimeSeconds = 1.5f;
+	NumberFormattingOptions.MinimumFractionalDigits = 0;
+	NumberFormattingOptions.MaximumFractionalDigits = 0;
 }
 
 void UStageWaitingTimer::NativeConstruct()
@@ -66,10 +68,7 @@ void UStageWaitingTimer::UpdateRemainTimeSeconds() const
 		// 남은 시간 업데이트
 		const float RemainSeconds = WaitingTimerEndSeconds - ServerTimeSeconds;
 		
-		FNumberFormattingOptions Options;
-		Options.MinimumFractionalDigits = 0;
-		Options.MaximumFractionalDigits = 0;
-		Text_RemainSeconds->SetText(FText::AsNumber(RemainSeconds, &Options));
+		Text_RemainSeconds->SetText(FText::AsNumber(RemainSeconds, &NumberFormattingOptions));
 
 		if (RemainSeconds < 5.5)
 		{

--- a/Source/Aura/Private/UI/Widget/ToolTip_CurrentMaxValue.cpp
+++ b/Source/Aura/Private/UI/Widget/ToolTip_CurrentMaxValue.cpp
@@ -5,8 +5,15 @@
 
 #include "Components/TextBlock.h"
 
+UToolTip_CurrentMaxValue::UToolTip_CurrentMaxValue(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	NumberFormattingOptions.MinimumFractionalDigits = 1;
+	NumberFormattingOptions.MaximumFractionalDigits = 1;
+}
+
 void UToolTip_CurrentMaxValue::UpdateValues(float CurrentValue, float MaxValue) const
 {
-	TextBlock_CurrentValue->SetText(FText::AsNumber(CurrentValue));
-	TextBlock_MaxValue->SetText(FText::AsNumber(MaxValue));
+	TextBlock_CurrentValue->SetText(FText::AsNumber(CurrentValue, &NumberFormattingOptions));
+	TextBlock_MaxValue->SetText(FText::AsNumber(MaxValue, &NumberFormattingOptions));
 }

--- a/Source/Aura/Public/UI/Widget/EquippedSpellGlobe.h
+++ b/Source/Aura/Public/UI/Widget/EquippedSpellGlobe.h
@@ -50,4 +50,7 @@ public:
 	float CooldownUpdateInterval;
 	
 	float RemainingTime = 0.f;
+
+private:
+	FNumberFormattingOptions NumberFormattingOptions;
 };

--- a/Source/Aura/Public/UI/Widget/StageWaitingTimer.h
+++ b/Source/Aura/Public/UI/Widget/StageWaitingTimer.h
@@ -46,4 +46,6 @@ private:
 
 	UPROPERTY(EditDefaultsOnly)
 	float TranslationTimeSeconds;
+
+	FNumberFormattingOptions NumberFormattingOptions;
 };

--- a/Source/Aura/Public/UI/Widget/ToolTip_CurrentMaxValue.h
+++ b/Source/Aura/Public/UI/Widget/ToolTip_CurrentMaxValue.h
@@ -17,6 +17,8 @@ class AURA_API UToolTip_CurrentMaxValue : public UUserWidget
 	GENERATED_BODY()
 
 public:
+	UToolTip_CurrentMaxValue(const FObjectInitializer& ObjectInitializer);
+	
 	UPROPERTY(meta=(BindWidget))
 	TObjectPtr<UTextBlock> TextBlock_CurrentValue;
 
@@ -24,4 +26,7 @@ public:
 	TObjectPtr<UTextBlock> TextBlock_MaxValue;
 
 	void UpdateValues(float CurrentValue, float MaxValue) const;
+
+private:
+	FNumberFormattingOptions NumberFormattingOptions;
 };


### PR DESCRIPTION
## 연관된 이슈

#244 

## 작업 내용

Health, Mana Globe의 ToolTip Widget이 값을 표시할 때 소수점 한자리까지만 표시하도록 변경한다.
추가로 FNumberFormattingOptions를 사용하는 위젯에서 멤버 변수로 저장해서 사용하도록 변경한다.

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요