### PR TITLE
FireBolt, FireBall Ability에서 Projectile 발사 방향을 계산할 때 항상 캐릭터 전방 방향으로 계산하도록 변경

### DIFF
--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_FireBall.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_FireBall.cpp
@@ -169,8 +169,7 @@ void UAuraAbility_FireBall::SpawnFireBalls() const
 
 	// Projectile 발사 방향 계산
 	const FVector TargetLocation = AuraASC->CursorTargetWeakPtr.IsValid() ? AuraASC->CursorTargetWeakPtr->GetActorLocation() : CachedImpactPoint;
-	const FVector StartLocation = AuraASC->CursorTargetWeakPtr.IsValid() ? CombatSocketLocation : AvatarActor->GetActorLocation();
-	const FVector CentralDirection = TargetLocation - StartLocation;
+	const FVector CentralDirection = TargetLocation - AvatarActor->GetActorLocation();
 	TArray<FVector> Directions;
 	UAuraBlueprintLibrary::GetSpreadDirections(Directions, NumFireBalls, SpreadAngle, CentralDirection);
 

--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_FireBolt.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_FireBolt.cpp
@@ -150,8 +150,7 @@ void UAuraAbility_FireBolt::SpawnFireBolts() const
 
 	// Projectile 발사 방향 계산
 	const FVector TargetLocation = AuraASC->CursorTargetWeakPtr.IsValid() ? AuraASC->CursorTargetWeakPtr->GetActorLocation() : CachedImpactPoint;
-	const FVector StartLocation = AuraASC->CursorTargetWeakPtr.IsValid() ? CombatSocketLocation : AvatarActor->GetActorLocation();
-	const FVector CentralDirection = TargetLocation - StartLocation;
+	const FVector CentralDirection = TargetLocation - AvatarActor->GetActorLocation();
 	TArray<FVector> Directions;
 	UAuraBlueprintLibrary::GetSpreadDirections(Directions, NumFireBolts, SpreadAngle, CentralDirection);
 


### PR DESCRIPTION
## 연관된 이슈

> #281 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요