### PR TITLE
클라이언트에서 ASC, AS를 가져올 수 없는 문제 해결

### DIFF
--- a/Source/Aura/Private/AuraBlueprintLibrary.cpp
+++ b/Source/Aura/Private/AuraBlueprintLibrary.cpp
@@ -246,16 +246,15 @@ float UAuraBlueprintLibrary::GetServerWorldTimeSecondsAsFloat(const UWorld* Worl
 	return GameStateBase ? GameStateBase->GetServerWorldTimeSeconds() : 0.0;
 }
 
-UAuraAbilitySystemComponent* UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(const APlayerController* PlayerController)
+UAuraAbilitySystemComponent* UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(APlayerState* PlayerState)
 {
-	UAbilitySystemComponent* ASC = PlayerController ? UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(PlayerController->GetPawn()) : nullptr;
-	return CastChecked<UAuraAbilitySystemComponent>(ASC);
+	UAbilitySystemComponent* ASC = PlayerState ? UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(PlayerState) : nullptr;
+	return CastChecked<UAuraAbilitySystemComponent>(ASC);	
 }
 
-UAuraAttributeSet* UAuraBlueprintLibrary::GetAuraAttributeSetChecked(const APlayerController* PlayerController)
+UAuraAttributeSet* UAuraBlueprintLibrary::GetAuraAttributeSetChecked(APlayerState* PlayerState)
 {
-	check(PlayerController);
-	return CastChecked<UAuraAttributeSet>(CastChecked<AAuraPlayerState>(PlayerController->PlayerState)->GetAttributeSet());
+	return CastChecked<UAuraAttributeSet>(CastChecked<AAuraPlayerState>(PlayerState)->GetAttributeSet());
 }
 
 APlayerController* UAuraBlueprintLibrary::GetSimulatedPlayerController(const UWorld* World)

--- a/Source/Aura/Private/UI/Widget/AttributeMenu.cpp
+++ b/Source/Aura/Private/UI/Widget/AttributeMenu.cpp
@@ -79,7 +79,7 @@ void UAttributeMenu::NativeConstruct()
 	UpdateAttributePointsChange(AuraPS->GetAttributePoints());
 
 	// Attribute Row의 값을 업데이트
-	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayer());
+	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayerState());
 	for (const TTuple<FGameplayTag, FGameplayAttribute>& Tuple : AuraAS->TagToAttributeMap)
 	{
 		UpdateAttributeValueChange(Tuple.Key, Tuple.Value.GetNumericValue(AuraAS));

--- a/Source/Aura/Private/UI/Widget/GameOverlay.cpp
+++ b/Source/Aura/Private/UI/Widget/GameOverlay.cpp
@@ -55,8 +55,8 @@ void UGameOverlay::NativeConstruct()
 	AuraPS->OnAttributePointsChangedDelegate.AddUObject(this, &ThisClass::OnAttributePointsChanged);
 	AuraPS->OnSpellPointsChangedDelegate.AddUObject(this, &ThisClass::OnSpellPointsChanged);
 
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
-	UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
+	UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayerState());
 	
 	for (const TTuple<FGameplayTag, FGameplayAttribute>& Pair : AuraAS->TagToAttributeMap)
 	{

--- a/Source/Aura/Private/UI/Widget/HealthGlobe.cpp
+++ b/Source/Aura/Private/UI/Widget/HealthGlobe.cpp
@@ -8,6 +8,7 @@
 #include "AbilitySystem/AuraAttributeSet.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "UI/Widget/ToolTip_CurrentMaxValue.h"
+#include "GameFramework/PlayerState.h"
 
 UHealthGlobe::UHealthGlobe(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -21,7 +22,7 @@ void UHealthGlobe::NativeConstruct()
 
 	check(ToolTipWidgetClass);
 
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	AuraASC->GetGameplayAttributeValueChangeDelegate(UAuraAttributeSet::GetHealthAttribute()).AddWeakLambda(this, [this](const FOnAttributeChangeData& Data)
 	{
 		UpdateHealth(Data.NewValue);
@@ -31,7 +32,7 @@ void UHealthGlobe::NativeConstruct()
 		UpdateMaxHealth(Data.NewValue);
 	});
 
-	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayer());
+	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayerState());
 	UpdateHealth(AuraAS->GetHealth());
 	UpdateMaxHealth(AuraAS->GetMaxHealth());
 }

--- a/Source/Aura/Private/UI/Widget/HealthManaSpells.cpp
+++ b/Source/Aura/Private/UI/Widget/HealthManaSpells.cpp
@@ -10,6 +10,7 @@
 #include "Data/SpellConfig.h"
 #include "Player/AuraPlayerController.h"
 #include "UI/Widget/EquippedSpellGlobe.h"
+#include "GameFramework/PlayerState.h"
 
 void UHealthManaSpells::NativeConstruct()
 {
@@ -38,7 +39,7 @@ void UHealthManaSpells::NativeConstruct()
 		SpellConfig = PlayerInterface->GetSpellConfig();
 	}
 
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	AuraASC->OnEquippedSpellAbilityChangedDelegate.AddUObject(this, &ThisClass::OnEquippedSpellChanged);
 
 	BroadcastInitialValues();
@@ -46,7 +47,7 @@ void UHealthManaSpells::NativeConstruct()
 
 void UHealthManaSpells::BroadcastInitialValues()
 {
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	TArray<TTuple<FGameplayTag, FGameplayTag>> StartupSpells;
 	AuraASC->GetSpellAndInputTagPairs(StartupSpells);
 	
@@ -66,7 +67,7 @@ void UHealthManaSpells::OnEquippedSpellChanged(bool bEquipped, const FGameplayTa
 
 void UHealthManaSpells::UpdateEquippedSpellCooldown(bool bEquipped, const FGameplayTag& SpellTag, UEquippedSpellGlobe* SpellGlobe)
 {
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	if (const FGameplayAbilitySpec* SpellSpec = AuraASC->GetSpellSpecForSpellTag(SpellTag))
 	{
 		// Spell Cooldown Tag는 하나만 존재한다고 가정

--- a/Source/Aura/Private/UI/Widget/ManaGlobe.cpp
+++ b/Source/Aura/Private/UI/Widget/ManaGlobe.cpp
@@ -8,6 +8,7 @@
 #include "AbilitySystem/AuraAttributeSet.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "UI/Widget/ToolTip_CurrentMaxValue.h"
+#include "GameFramework/PlayerState.h"
 
 UManaGlobe::UManaGlobe(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -21,7 +22,7 @@ void UManaGlobe::NativeConstruct()
 
 	check(ToolTipWidgetClass);
 
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	AuraASC->GetGameplayAttributeValueChangeDelegate(UAuraAttributeSet::GetManaAttribute()).AddWeakLambda(this, [this](const FOnAttributeChangeData& Data)
 	{
 		UpdateMana(Data.NewValue);
@@ -31,7 +32,7 @@ void UManaGlobe::NativeConstruct()
 		UpdateMaxMana(Data.NewValue);
 	});
 
-	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayer());
+	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayerState());
 	UpdateMana(AuraAS->GetMana());
 	UpdateMaxMana(AuraAS->GetMaxMana());
 }

--- a/Source/Aura/Private/UI/Widget/SpellMenu.cpp
+++ b/Source/Aura/Private/UI/Widget/SpellMenu.cpp
@@ -51,7 +51,7 @@ void USpellMenu::NativeConstruct()
 	AuraPS->OnSpellPointsChangedDelegate.AddUObject(this, &ThisClass::UpdateSpellPointsChange);
 
 	/* Spell Tree */
-	AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	AuraASC->OnActivatableAbilitiesReplicatedDelegate.AddUObject(this, &ThisClass::OnSpellGiven);
 	
 	OffensiveSpellTree->GlobeButton_1->OnSpellGlobeButtonSelectedDelegate.BindUObject(this, &ThisClass::OnSpellGlobeButtonSelected);
@@ -166,7 +166,7 @@ bool USpellMenu::CanSpendPoint() const
 		if (const UAuraGameplayAbility* AuraAbilityCDO = SpellAbilityClass->GetDefaultObject<UAuraGameplayAbility>())
 		{
 			// 현재 플레이어의 레벨이 Spell을 Unlock 할 수 있는 레벨인지 반환
-			const int32 PlayerLevel = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayer())->GetLevel();
+			const int32 PlayerLevel = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayerState())->GetLevel();
 			return PlayerLevel >= AuraAbilityCDO->UnlockRequiredLevel;
 		}
 	}

--- a/Source/Aura/Private/UI/Widget/TextValueButtonRow.cpp
+++ b/Source/Aura/Private/UI/Widget/TextValueButtonRow.cpp
@@ -7,6 +7,7 @@
 #include "AbilitySystem/AuraAbilitySystemComponent.h"
 #include "Components/Button.h"
 #include "UI/Widget/SquareButton.h"
+#include "GameFramework/PlayerState.h"
 
 void UTextValueButtonRow::NativeConstruct()
 {
@@ -17,6 +18,6 @@ void UTextValueButtonRow::NativeConstruct()
 
 void UTextValueButtonRow::OnUpgradeButtonClicked()
 {
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	AuraASC->ServerUpgradeAttribute(AttributeTag);
 }

--- a/Source/Aura/Private/UI/Widget/XPBar.cpp
+++ b/Source/Aura/Private/UI/Widget/XPBar.cpp
@@ -9,6 +9,7 @@
 #include "Components/ProgressBar.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "UI/Widget/ToolTip_XPBar.h"
+#include "GameFramework/PlayerState.h"
 
 UXPBar::UXPBar(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -22,7 +23,7 @@ void UXPBar::NativeConstruct()
 
 	check(ToolTipWidgetClass);
 
-	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayer());
+	UAuraAbilitySystemComponent* AuraASC = UAuraBlueprintLibrary::GetAuraAbilitySystemComponentChecked(GetOwningPlayerState());
 	AuraASC->GetGameplayAttributeValueChangeDelegate(UAuraAttributeSet::GetXPAttribute()).AddWeakLambda(this, [this](const FOnAttributeChangeData& Data)
 	{
 		UpdateXPChange(Data.NewValue);
@@ -32,7 +33,7 @@ void UXPBar::NativeConstruct()
 		UpdateLevelChange(Data.NewValue);
 	});
 
-	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayer());
+	const UAuraAttributeSet* AuraAS = UAuraBlueprintLibrary::GetAuraAttributeSetChecked(GetOwningPlayerState());
 	UpdateXPChange(AuraAS->GetXP());
 	UpdateLevelChange(AuraAS->GetLevel());
 }

--- a/Source/Aura/Public/AuraBlueprintLibrary.h
+++ b/Source/Aura/Public/AuraBlueprintLibrary.h
@@ -104,8 +104,8 @@ public:
 	// 구할 수 없으면 0.f을 반환한다.
 	static float GetServerWorldTimeSecondsAsFloat(const UWorld* World);
 
-	static UAuraAbilitySystemComponent* GetAuraAbilitySystemComponentChecked(const APlayerController* PlayerController);
-	static UAuraAttributeSet* GetAuraAttributeSetChecked(const APlayerController* PlayerController);
+	static UAuraAbilitySystemComponent* GetAuraAbilitySystemComponentChecked(APlayerState* PlayerState);
+	static UAuraAttributeSet* GetAuraAttributeSetChecked(APlayerState* PlayerState);
 
 	// SimulatedProxy의 Auth Player Controller 반환
 	static APlayerController* GetSimulatedPlayerController(const UWorld* World);


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#314 

## 📄 작업 내용 요약
위젯에서 ASC, AS를 가져올 때 OwningPlayerController 대신 OwningPlayerState를 사용하도록 변경