### PR TITLE
UScalableStageConfig::PostEditChangeProperty()에서 발생하는 패키지 빌드 오류 해결

### DIFF
--- a/Source/Aura/Private/Data/ScalableStageConfig.cpp
+++ b/Source/Aura/Private/Data/ScalableStageConfig.cpp
@@ -10,12 +10,14 @@ void UScalableStageConfig::PostLoad()
 	SortAscendingSpawnEnemyInfosByThreatValue();
 }
 
+#if WITH_EDITOR
 void UScalableStageConfig::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
 	Super::PostEditChangeProperty(PropertyChangedEvent);
 
 	SortAscendingSpawnEnemyInfosByThreatValue();
 }
+#endif
 
 void UScalableStageConfig::SortAscendingSpawnEnemyInfosByThreatValue()
 {

--- a/Source/Aura/Public/Data/ScalableStageConfig.h
+++ b/Source/Aura/Public/Data/ScalableStageConfig.h
@@ -36,7 +36,10 @@ class AURA_API UScalableStageConfig : public UDataAsset
 
 public:
 	virtual void PostLoad() override;
+	
+#if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
 	
 	UPROPERTY(EditDefaultsOnly)
 	int32 MaxStage;


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#306 

## 📄 작업 내용 요약
PostEditChangeProperty() 함수를 에디터에서만 사용하도록 변경