### PR TITLE
menu를 열거나 Level Sequence를 실행할 때 Cursor Trace 방지

### DIFF
--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_EnemyMelee.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_EnemyMelee.cpp
@@ -15,6 +15,7 @@ UAuraAbility_EnemyMelee::UAuraAbility_EnemyMelee()
 	AbilityTags.AddTag(AuraGameplayTags::Abilities_EnemyAttack);
 	bCanAttackMultiTarget = true;
 	DamageTypeTag = AuraGameplayTags::Damage_Type_Physical;
+	bNeedCursorTargetHitResult = false;
 }
 
 void UAuraAbility_EnemyMelee::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,

--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_EnemyRange.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_EnemyRange.cpp
@@ -11,6 +11,7 @@ UAuraAbility_EnemyRange::UAuraAbility_EnemyRange()
 	InstancingPolicy = EGameplayAbilityInstancingPolicy::InstancedPerActor;
 	AbilityTags.AddTag(AuraGameplayTags::Abilities_EnemyAttack);
 	DamageTypeTag = AuraGameplayTags::Damage_Type_Physical;
+	bNeedCursorTargetHitResult = false;
 }
 
 void UAuraAbility_EnemyRange::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,

--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_RangeShaman.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraAbility_RangeShaman.cpp
@@ -8,4 +8,5 @@
 UAuraAbility_RangeShaman::UAuraAbility_RangeShaman()
 {
 	DamageTypeTag = AuraGameplayTags::Damage_Type_Fire;
+	bNeedCursorTargetHitResult = false;
 }

--- a/Source/Aura/Private/Component/LevelSequenceManageComponent.cpp
+++ b/Source/Aura/Private/Component/LevelSequenceManageComponent.cpp
@@ -82,6 +82,18 @@ void ULevelSequenceManageComponent::StopCurrentPlayingLevelSequence()
 	StopLevelSequence(CurrentPlayingLevelSequenceTag);
 }
 
+bool ULevelSequenceManageComponent::IsPlayingLevelSequence() const
+{
+	if (LevelSequenceActorMap.Contains(CurrentPlayingLevelSequenceTag))
+	{
+		if (const ALevelSequenceActor* LevelSequenceActor = LevelSequenceActorMap[CurrentPlayingLevelSequenceTag])
+		{
+			return LevelSequenceActor->SequencePlayer && LevelSequenceActor->SequencePlayer->IsPlaying();
+		}
+	}
+	return false;
+}
+
 void ULevelSequenceManageComponent::SetLevelSequenceActorLocation(const FName& LevelSequenceTag, const FVector& NewLocation)
 {
 	if (LevelSequenceActorMap.Contains(LevelSequenceTag))

--- a/Source/Aura/Private/Player/AuraPlayerController.cpp
+++ b/Source/Aura/Private/Player/AuraPlayerController.cpp
@@ -30,10 +30,7 @@ void AAuraPlayerController::PlayerTick(float DeltaTime)
 	// only called if the PlayerController has a PlayerInput object. it will not be called in non-locally controlled PlayerController.
 	Super::PlayerTick(DeltaTime);
 
-	if (bCursorTraceEnabled)
-	{
-		CursorTrace();
-	}
+	CursorTrace();
 }
 
 void AAuraPlayerController::OnRep_Pawn()
@@ -92,8 +89,6 @@ void AAuraPlayerController::EnableUIInput()
 		Subsystem->AddMappingContext(UIContext, 1);
 	}
 	DisableAbilityInput();
-
-	EnableCursorTrace(false);
 }
 
 void AAuraPlayerController::DisableUIInput()
@@ -103,8 +98,6 @@ void AAuraPlayerController::DisableUIInput()
 		Subsystem->RemoveMappingContext(UIContext);
 	}
 	EnableAbilityInput();
-
-	EnableCursorTrace(true);
 }
 
 void AAuraPlayerController::EnableCinematicInput()
@@ -281,28 +274,6 @@ void AAuraPlayerController::CursorTrace()
 		{
 			CurrentInteractionInterface->HighlightActor();
 		}		
-	}
-}
-
-void AAuraPlayerController::EnableCursorTrace(bool bEnabled)
-{
-	if (bEnabled)
-	{
-		// 다음 프레임에 수행해 잘못된 커서 위치에서 CursorTrace() 호출을 방지 (Pause Menu)
-		GetWorldTimerManager().SetTimerForNextTick(FTimerDelegate::CreateLambda([this]()
-		{
-			bCursorTraceEnabled = true;
-		}));
-	}
-	else
-	{
-		bCursorTraceEnabled = false;
-		if (IInteractionInterface* InteractionInterface = Cast<IInteractionInterface>(TargetFromCurrentFrame))
-		{
-			InteractionInterface->UnHighlightActor();
-		}
-		TargetFromCurrentFrame = nullptr;
-		TargetFromPrevFrame = nullptr;
 	}
 }
 

--- a/Source/Aura/Public/AbilitySystem/Abilities/AuraDamageAbility.h
+++ b/Source/Aura/Public/AbilitySystem/Abilities/AuraDamageAbility.h
@@ -31,6 +31,8 @@ protected:
 	// 매 실행마다 초기화되어야 하는 내부 변수 초기화
 	// 하위 클래스의 InstancingPolicy가 InstancedPerActor인 경우에는 해당 함수 호출 필요
 	virtual void ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData) override;
+
+	virtual bool CanActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayTagContainer* SourceTags, const FGameplayTagContainer* TargetTags, FGameplayTagContainer* OptionalRelevantTags) const override;
 	
 	UPROPERTY(EditDefaultsOnly, Category="Aura|Damage")
 	TSubclassOf<UGameplayEffect> DamageEffectClass;
@@ -71,6 +73,10 @@ protected:
 
 	// UAuraAbilitySystemComponent의 TargetActorWeakPtr를 초기화해야 하는 지를 나타냄 
 	uint8 bShouldClearTargetActor : 1;
+
+	// AAuraPlayerController::CursorTrace()에서 커서 위치에 Trace를 수행한 TargetHitResult를 사용하는 어빌리티인지 나타낸다.
+	UPROPERTY(EditDefaultsOnly, Category="Aura|Damage")
+	uint8 bNeedCursorTargetHitResult : 1;
 
 	// ============================================================================
 	// Debuff

--- a/Source/Aura/Public/Component/LevelSequenceManageComponent.h
+++ b/Source/Aura/Public/Component/LevelSequenceManageComponent.h
@@ -32,6 +32,8 @@ public:
 	void StopLevelSequence(const FName& LevelSequenceTag);
 	void StopCurrentPlayingLevelSequence();
 
+	bool IsPlayingLevelSequence() const;
+
 	void SetLevelSequenceActorLocation(const FName& LevelSequenceTag, const FVector& NewLocation);
 
 protected:

--- a/Source/Aura/Public/Player/AuraPlayerController.h
+++ b/Source/Aura/Public/Player/AuraPlayerController.h
@@ -135,6 +135,10 @@ private:
 
 	void CursorTrace();
 
+	// Cursor Target에 대한 Highlight 활성화 여부
+	bool bEnableHighlight = true;
+	void EnableHighlight(bool bEnabled);
+
 	// Cached Target HitResult Under Cursor
 	FHitResult TargetHitResult;
 

--- a/Source/Aura/Public/Player/AuraPlayerController.h
+++ b/Source/Aura/Public/Player/AuraPlayerController.h
@@ -139,6 +139,10 @@ private:
 	bool bEnableHighlight = true;
 	void EnableHighlight(bool bEnabled);
 
+	// Cursor Target에 대한 TargetHitResult Caching 활성화 여부
+	bool bEnableCachingTargetHitResult = true;
+	void EnableCachingTargetHitResult(bool bEnabled);
+
 	// Cached Target HitResult Under Cursor
 	FHitResult TargetHitResult;
 
@@ -270,6 +274,8 @@ private:
 
 	// PauseMenu Level Sequence Actor를 PlayerController의 Pawn에 부착한다.
 	void AttachPauseMenuLevelSequenceActorToPawn() const;
+
+	void OnLevelSequencePlayerStop(const FName& LevelSequenceTag);
 
 	// ============================================================================
 	// Stage

--- a/Source/Aura/Public/Player/AuraPlayerController.h
+++ b/Source/Aura/Public/Player/AuraPlayerController.h
@@ -135,12 +135,6 @@ private:
 
 	void CursorTrace();
 
-	// CursorTrace 활성화/비활성화
-	void EnableCursorTrace(bool bEnabled);
-	
-	// CursorTrace()를 호출할 수 있는지 여부
-	bool bCursorTraceEnabled = true;
-
 	// Cached Target HitResult Under Cursor
 	FHitResult TargetHitResult;
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#279 

## 📄 작업 내용 요약
기존 작업 Revert
Revert "Menu를 열면 CursorTrace() 호출을 방지해 Highlight, TargetHitResult 업데이트 방지 (#280)"

Menu를 열면 Cursor Target에 대한 Highlight 비활성화, 닫으면 활성화
Level Sequence를 재생하면 Highlight 비활성화, 종료하면 활성화

Level Sequence를 재생할 때 Cursor Target에 대한 TargetHitResult Caching 비활성화, 종료할 때 다시 활성화
Cursor Target에 대한 TargetHitResult를 사용하는 스펠의 경우, TargetHitResult가 유효하지 않으면 스펠 어빌리티 활성화 방지