### PR TITLE
Bad Timing으로 인해 클라이언트에서 Beacon의 ToolTip Widget Text가 제대로 설정되지 않는 현상 수정

### DIFF
--- a/Source/Aura/Private/Actor/Beacon_StartStage.cpp
+++ b/Source/Aura/Private/Actor/Beacon_StartStage.cpp
@@ -47,6 +47,19 @@ void ABeacon_StartStage::HighlightActor()
 
 	if (!bHasInteractedWithPlayer)
 	{
+		// 처음 표시할 때 ToolTip Widget Text 설정
+		if (!bHasSetToolTipWidgetText)
+		{
+			if (const IPlayerInterface* PlayerInterface = Cast<IPlayerInterface>(GetWorld() ? GetWorld()->GetFirstPlayerController() : nullptr))
+			{
+				if (const UToolTip_Beacon_StartStage* ToolTipWidget = Cast<UToolTip_Beacon_StartStage>(TooltipWidgetComponent->GetWidget()))
+				{
+					ToolTipWidget->SetKeyText(PlayerInterface->GetInteractKeyMappedToAction().ToString());
+					bHasSetToolTipWidgetText = true;
+				}
+			}
+		}
+		
 		TooltipWidgetComponent->SetVisibility(true);
 	}
 }
@@ -91,15 +104,6 @@ void ABeacon_StartStage::BeginPlay()
 
 	DynamicMaterialInstance = UMaterialInstanceDynamic::Create(MeshComponent->GetMaterial(0), this);
 	MeshComponent->SetMaterial(0, DynamicMaterialInstance);
-
-	// ToolTip Text 설정
-	if (const UToolTip_Beacon_StartStage* ToolTipWidget = Cast<UToolTip_Beacon_StartStage>(TooltipWidgetComponent->GetWidget()))
-	{
-		if (const IPlayerInterface* PlayerInterface = Cast<IPlayerInterface>(GetWorld() ? GetWorld()->GetFirstPlayerController() : nullptr))
-		{
-			ToolTipWidget->SetKeyText(PlayerInterface->GetInteractKeyMappedToAction().ToString());
-		}
-	}
 
 	// SpawnBeacon Level Sequence가 끝나고 다시 표시
 	SetMeshComponentHiddenInGame(true);

--- a/Source/Aura/Public/Actor/Beacon_StartStage.h
+++ b/Source/Aura/Public/Actor/Beacon_StartStage.h
@@ -70,4 +70,7 @@ private:
 
 	UPROPERTY(VisibleAnywhere)
 	TObjectPtr<UWidgetComponent> TooltipWidgetComponent;
+
+	// ToolTip Widget의 Text가 제대로 설정됐는지
+	bool bHasSetToolTipWidgetText = false;
 };


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#283 

## 📄 작업 내용 요약
Beacon의 ToolTip을 처음 표시할 때 ToolTip Widget Text를 설정하도록 변경