### PR TITLE
GameOverlay를 초기화하고 표시하는 시점 변경

### DIFF
--- a/Source/Aura/Private/Character/AuraCharacter.cpp
+++ b/Source/Aura/Private/Character/AuraCharacter.cpp
@@ -19,7 +19,6 @@
 #include "Interface/StageSystemInterface.h"
 #include "Player/AuraPlayerController.h"
 #include "Player/AuraPlayerState.h"
-#include "UI/HUD/AuraHUD.h"
 #include "UI/Widget/PlayerNameplate.h"
 #include "GameFramework/GameModeBase.h"
 
@@ -317,21 +316,12 @@ void AAuraCharacter::InitAbilityActorInfo()
 			AuraASC->AbilityFailedCallbacks.AddUObject(AuraASC, &UAuraAbilitySystemComponent::OnAbilityFailed);
 		}
 
-		// Overlay Widget 초기화
-		if (APlayerController* PC = GetController<APlayerController>())
+		if (AAuraPlayerController* AuraPC = GetController<AAuraPlayerController>())
 		{
-			if (AAuraHUD* AuraHUD = PC->GetHUD<AAuraHUD>())
+			if (AuraPC->IsLocalController())
 			{
-				AuraHUD->InitOverlay();
-			}
-
-			if (PC->IsLocalController())
-			{
-				if (AAuraPlayerController* AuraPC = Cast<AAuraPlayerController>(PC))
-				{
-					// Stage를 시작하기 위해 ASC 초기화를 ServerRPC로 전송
-					AuraPC->ServerNotifyASCInitToGameMode();
-				}
+				// Stage를 시작하기 위해 ASC 초기화를 ServerRPC로 전송
+				AuraPC->ServerNotifyASCInitToGameMode();
 			}
 		}
 	}

--- a/Source/Aura/Private/Player/AuraPlayerController.cpp
+++ b/Source/Aura/Private/Player/AuraPlayerController.cpp
@@ -184,6 +184,11 @@ void AAuraPlayerController::SetLevelSequenceActorLocation(const FName& LevelSequ
 
 void AAuraPlayerController::HandleInitialLogic() const
 {
+	// GameOverlay Widget 초기화
+	if (AAuraHUD* AuraHUD = GetHUD<AAuraHUD>())
+	{
+		AuraHUD->InitOverlay();
+	}
 	ShowPreStageHUD();
 	ShowAllMenuShortcutAlert();
 }


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#330 

## 📄 작업 내용 요약
기존에는 InitAbilityActorInfo()에서 수행했지만, 여러 로직의 변경으로 기존 함수에서 수행하면 위젯의 NativeConstruct()에서 PlayerState를 가져올 때 오류가 발생하는 문제가 존재한다.

이를 해결하기 위해 SpawnBeacon Level Sequence가 끝난 뒤 초기 로직을 수행하는 HandleInitialLogic()에서 수행하도록 변경한다.