### PR TITLE
어빌리티별로 원하는 Input TriggerEvent로 실행될 수 있도록 개선

### DIFF
--- a/Source/Aura/Private/AbilitySystem/Abilities/AuraGameplayAbility.cpp
+++ b/Source/Aura/Private/AbilitySystem/Abilities/AuraGameplayAbility.cpp
@@ -7,6 +7,7 @@
 
 UAuraGameplayAbility::UAuraGameplayAbility()
 {
+	bUseTriggeredEvent = true;
 	UnlockRequiredLevel = 1;
 	MaxSpellLevel = 4;
 }

--- a/Source/Aura/Private/AbilitySystem/AuraAbilitySystemComponent.cpp
+++ b/Source/Aura/Private/AbilitySystem/AuraAbilitySystemComponent.cpp
@@ -84,9 +84,9 @@ void UAuraAbilitySystemComponent::AddAbilities(const TArray<TSubclassOf<UGamepla
 	}
 }
 
-void UAuraAbilitySystemComponent::AbilityInputPressed(int32 InputID)
+void UAuraAbilitySystemComponent::AbilityInputPressed(int32 InputID, bool bUseTriggeredEvent)
 {
-	if (FGameplayAbilitySpec* AbilitySpec = FindAbilitySpecFromInputID(InputID))
+	if (FGameplayAbilitySpec* AbilitySpec = FindAbilitySpecFromInputIDAndTriggerEvent(InputID, bUseTriggeredEvent))
 	{
 		if (!AbilitySpec->IsActive())
 		{
@@ -94,6 +94,21 @@ void UAuraAbilitySystemComponent::AbilityInputPressed(int32 InputID)
 		}
 		AbilitySpecInputPressed(*AbilitySpec);
 	}
+}
+
+FGameplayAbilitySpec* UAuraAbilitySystemComponent::FindAbilitySpecFromInputIDAndTriggerEvent(int32 InputID, bool bUseTriggeredEvent)
+{
+	if (FGameplayAbilitySpec* AbilitySpec = FindAbilitySpecFromInputID(InputID))
+	{
+		if (const UAuraGameplayAbility* AuraAbilityCDO = Cast<UAuraGameplayAbility>(AbilitySpec->Ability))
+		{
+			if (AuraAbilityCDO->bUseTriggeredEvent == bUseTriggeredEvent)
+			{
+				return AbilitySpec;
+			}
+		}
+	}
+	return nullptr;
 }
 
 void UAuraAbilitySystemComponent::AbilityInputReleased(int32 InputID)

--- a/Source/Aura/Private/Player/AuraPlayerController.cpp
+++ b/Source/Aura/Private/Player/AuraPlayerController.cpp
@@ -565,11 +565,11 @@ void AAuraPlayerController::OnCloseCinematicActionStarted()
 	}
 }
 
-void AAuraPlayerController::AbilityInputPressed(int32 InputID)
+void AAuraPlayerController::AbilityInputPressed(int32 InputID, bool bUseTriggeredEvent)
 {
 	if (GetAuraAbilitySystemComponent())
 	{
-		AuraAbilitySystemComponent->AbilityInputPressed(InputID);
+		AuraAbilitySystemComponent->AbilityInputPressed(InputID, bUseTriggeredEvent);
 	}
 }
 

--- a/Source/Aura/Public/AbilitySystem/Abilities/AuraGameplayAbility.h
+++ b/Source/Aura/Public/AbilitySystem/Abilities/AuraGameplayAbility.h
@@ -16,6 +16,10 @@ class AURA_API UAuraGameplayAbility : public UGameplayAbility
 
 public:
 	UAuraGameplayAbility();
+
+	// true면 ETriggerEvent::Triggered로 실행되고, false면 ETriggerEvent::Started로 실행된다. 
+	UPROPERTY(EditDefaultsOnly, Category="Aura|Input")
+	uint8 bUseTriggeredEvent : 1;
 	
 	// Ability를 활성화하는 Input Key를 나타내는 Tag
 	UPROPERTY(EditDefaultsOnly, Category="Aura|Input")

--- a/Source/Aura/Public/AbilitySystem/AuraAbilitySystemComponent.h
+++ b/Source/Aura/Public/AbilitySystem/AuraAbilitySystemComponent.h
@@ -43,10 +43,13 @@ public:
 	// Abilities의 Ability Class의 AbilitySpec을 생성해 GiveAbility를 수행하는 함수 
 	void AddAbilities(const TArray<TSubclassOf<UGameplayAbility>>& Abilities, int32 InLevel);
 
-	// InputID에 해당하는 Ability의 Press Event를 발생시키는 함수
-	void AbilityInputPressed(int32 InputID);
+	// InputID와 bUseTriggeredEvent에 해당하는 Ability를 실행하고 Pressed Event를 발생시키는 함수
+	void AbilityInputPressed(int32 InputID, bool bUseTriggeredEvent);
 
-	// InputID에 해당하는 Ability의 Release Event를 발생시키는 함수
+	// InputID와 bUseTriggeredEvent에 해당하는 어빌리티를 찾아 FGameplayAbilitySpec*을 반환한다. 
+	FGameplayAbilitySpec* FindAbilitySpecFromInputIDAndTriggerEvent(int32 InputID, bool bUseTriggeredEvent);
+
+	// InputID에 해당하는 Ability의 Released Event를 발생시키는 함수
 	void AbilityInputReleased(int32 InputID);
 
 	// HitResultUnderMouse의 Hit Actor를 저장하는 Weak Ptr

--- a/Source/Aura/Public/Input/AuraInputComponent.h
+++ b/Source/Aura/Public/Input/AuraInputComponent.h
@@ -32,7 +32,8 @@ void UAuraInputComponent::BindAbilityActions(UAuraInputConfig* InputConfig, User
 		{
 			if (PressedFunc)
 			{
-				BindAction(Mapping.InputAction, ETriggerEvent::Triggered, Object, PressedFunc, Mapping.InputID);
+				BindAction(Mapping.InputAction, ETriggerEvent::Triggered, Object, PressedFunc, Mapping.InputID, true);
+				BindAction(Mapping.InputAction, ETriggerEvent::Started, Object, PressedFunc, Mapping.InputID, false);
 			}
 			if (ReleasedFunc)
 			{

--- a/Source/Aura/Public/Player/AuraPlayerController.h
+++ b/Source/Aura/Public/Player/AuraPlayerController.h
@@ -159,7 +159,7 @@ private:
 	// Input
 	// ============================================================================
 
-	void AbilityInputPressed(int32 InputID);
+	void AbilityInputPressed(int32 InputID, bool bUseTriggeredEvent);
 	void AbilityInputReleased(int32 InputID);
 
 	// Input Event와 Ability 연동


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#366 

## 📄 작업 내용 요약
- Pressed Func를 등록할 때 Started와 Triggered Event에 대해 모두 등록하고, 콜백 함수를 호출할 때 InputID와 TriggeredEvent에 등록됐는지 여부를 함께 전달
- Ability마다 Triggered Event로 호출할 것인지 여부를 나타내는 프로퍼티 설정
- Key에 등록된 Pressed 콜백 함수가 호출되면 해당하는 어빌리티의 Pressed Event를 발생시킴