### PR TITLE
Respawn Timer가 표시되고 PauseMenu를 열어 GameOverlay를 숨기면 다시 PauseMenu를 닫아야 Respawn Timer가 진행되는 문제 해결

### DIFF
--- a/Source/Aura/Private/UI/Widget/GameOverlay.cpp
+++ b/Source/Aura/Private/UI/Widget/GameOverlay.cpp
@@ -98,6 +98,12 @@ void UGameOverlay::CloseAllMenu()
 	}
 }
 
+void UGameOverlay::ShowGameOverlay(bool bShow)
+{
+	SetVisibility(bShow ? ESlateVisibility::SelfHitTestInvisible : ESlateVisibility::HitTestInvisible);
+	SetRenderOpacity(bShow ? 1.f : 0.f);
+}
+
 void UGameOverlay::OnRespawnStarted(float RespawnTimerEndSeconds)
 {
 	if (RespawnTimerEndSeconds > 0.0)
@@ -275,14 +281,14 @@ void UGameOverlay::OpenPauseMenu()
 	PauseMenu->GetOnRemovedDelegate().AddUObject(this, &ThisClass::OnPauseMenuClosed);
 	PauseMenu->AddToViewport(1);
 
-	// GameOverlay 숨김
-	SetVisibility(ESlateVisibility::Collapsed);
+	ShowGameOverlay(false);
 }
 
 void UGameOverlay::OnPauseMenuClosed()
 {
 	PauseMenu = nullptr;
-	SetVisibility(ESlateVisibility::SelfHitTestInvisible);
+
+	ShowGameOverlay(true);
 }
 
 void UGameOverlay::OpenTutorialMenu()

--- a/Source/Aura/Public/UI/Widget/GameOverlay.h
+++ b/Source/Aura/Public/UI/Widget/GameOverlay.h
@@ -49,6 +49,10 @@ public:
 	// 현재 열린 모든 메뉴를 닫는다.
 	void CloseAllMenu();
 
+	// bShow가 true면 GameOverlay를 화면에 표시하고, false면 숨긴다.
+	// 마우스 커서로 상호작용(ToolTip Widget)을 방지하고, tick 등의 로직(Respawn Timer)은 처리한다.
+	void ShowGameOverlay(bool bShow);
+
 	// ============================================================================
 	// Respawn Timer
 	// ============================================================================


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#351 

## 📄 작업 내용 요약
